### PR TITLE
HTTPSify the docs

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -18,7 +18,7 @@
 
 	<!-- CSS
   ================================================== -->
-  <link href='http://fonts.googleapis.com/css?family=Quicksand:300' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Quicksand:300' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" href="stylesheets/base.css">
 	<link rel="stylesheet" href="stylesheets/skeleton.css">
 	<link rel="stylesheet" href="stylesheets/layout.css">
@@ -26,7 +26,7 @@
 	
 
 	<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+		<script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 
 	<!-- Favicons
@@ -42,7 +42,7 @@
 </head>
 <body>
 
-<a href="https://github.com/cwmyers/monet.js"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+<a href="https://github.com/cwmyers/monet.js"><img style="position: absolute; top: 0; right: 0; border: 0;" src="//s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 
 
 	<!-- Primary Page Layout
@@ -69,7 +69,7 @@
 
 	<!-- JS
 	================================================== -->
-	<script src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
+	<script src="//code.jquery.com/jquery-1.7.1.min.js"></script>
 	<script src="javascripts/tabs.js"></script>
     <script type="text/javascript" src="javascripts/prettify.js"></script>
     <script type="text/javascript" src="javascripts/monet.js"></script>

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Download the [zip][gitZip] or [tar][gitTar] ball.
 
 ##Source code
 
-The source is available at: [http://github.com/cwmyers/monet.js](http://github.com/cwmyers/monet.js).
+The source is available at: [https://github.com/cwmyers/monet.js](https://github.com/cwmyers/monet.js).
 
 ##Installation
 
@@ -975,7 +975,7 @@ Executes the function wrapped in the `Reader` with the supplied `config`.
 ## Free
 The `Free` monad is a monad that is able to separate instructions from their interpreter.  There are many applications for this monad, and one of them is for implementing Trampolines, (which is a way to make recursion constant stack for languages that don't support tail call elimination, like JavaScript!).
 
-Please see [Ken Scambler](http://twitter.com/KenScambler)'s [excellent talk](http://www.slideshare.net/kenbot/running-free-with-the-monads) and [example project](https://github.com/kenbot/free) to get an in-depth understanding of this very useful monad.
+Please see [Ken Scambler](https://twitter.com/KenScambler)'s [excellent talk](http://www.slideshare.net/kenbot/running-free-with-the-monads) and [example project](https://github.com/kenbot/free) to get an in-depth understanding of this very useful monad.
 
 #### Creating a Free monad
 
@@ -1071,7 +1071,7 @@ a method to be applied in the following ways:
 
 ##Author
 
-Written and maintained by Chris Myers [@cwmyers](http://twitter.com/cwmyers). Follow Monet.js at [@monetjs](http://twitter.com/monetjs).
+Written and maintained by Chris Myers [@cwmyers](https://twitter.com/cwmyers). Follow Monet.js at [@monetjs](https://twitter.com/monetjs).
 
 
 [functionalJava]: http://functionaljava.org/


### PR DESCRIPTION
GitHub Pages can now be loaded via HTTPS. There are, however, some resources
referenced via HTTP which is blocked in Chrome by default if the page itself is
loaded over TLS. This updates the references to be protocol-relative and I also
took the liberty to upgrade some of the stand-alone links to GitHub and Twitter.
