### PR TITLE
fix global leak of loop variable `i`

### DIFF
--- a/src/main/javascript/monet.js
+++ b/src/main/javascript/monet.js
@@ -264,7 +264,7 @@
 
     List.fromArray = function (array) {
         var l = Nil
-        for (i = array.length; i--; i <= 0) {
+        for (var i = array.length; i--; i <= 0) {
             l = l.cons(array[i])
         }
         return l


### PR DESCRIPTION
The loop variable `i` in List.fromArray was not defined locally as a var, so it's definition is hoisted to the global scope.
