### PR TITLE
Fix invalid conversions from Either to Maybe and Validation

### DIFF
--- a/src/main/javascript/monet.js
+++ b/src/main/javascript/monet.js
@@ -685,10 +685,10 @@
             return this.isRightValue ? this.map(rightFn) : this.leftMap(leftFn)
         },
         toMaybe: function () {
-            return this.isRight() ? Some(this.val) : None()
+            return this.isRight() ? Some(this.value) : None()
         },
         toValidation: function () {
-            return this.isRight() ? Success(this.val) : Fail(this.val)
+            return this.isRight() ? Success(this.value) : Fail(this.value)
         }
     }
 

--- a/src/test/javascript/either_spec.js
+++ b/src/test/javascript/either_spec.js
@@ -74,6 +74,12 @@ describe('An Either', function () {
                 return "right " + s
             })).toBeRightWith("right abcd")
         })
+        it('can be converted to Maybe.Some', function() {
+          expect(rightString.toMaybe().isSome()).toBe(true)
+        })
+        it('can be converted to Validation.Success', function() {
+          expect(rightString.toValidation().success()).not.toBeUndefined()
+        })
     })
 
     var leftString = Either.Left("error dude")
@@ -129,6 +135,13 @@ describe('An Either', function () {
             }, function () {
                 throw "right"
             })).toBeLeftWith("left: error dude")
+        })
+        
+        it('can be converted to Maybe.None', function() {
+          expect(leftString.toMaybe().isNone()).toBe(true)
+        })
+        it('can be converted to Validation.Fail', function() {
+          expect(leftString.toValidation().fail()).not.toBeUndefined()
         })
 
     })


### PR DESCRIPTION
The prior implementation used a property undefined on `Either` `(this.val)`.  It appears that `this.value` was the intended property.
