### PR TITLE
remove HKT in typescript bindings, fix TS 2.4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "karma-jasmine": "1.1.0",
     "karma-phantomjs-launcher": "1.0.4",
     "karma-safari-launcher": "1.0.0",
-    "typescript": "2.3.4",
+    "typescript": "2.4.2",
     "uglify-js": "3.0.18"
   },
   "scripts": {

--- a/test/typings/free-spec.ts
+++ b/test/typings/free-spec.ts
@@ -1,8 +1,8 @@
-import { Free, Functor } from '../../src/monet';
+import { Free } from '../../src/monet';
 
 // I hope you don't write real app this way, but this
 // is not a good place to pull in Coyonedas and IO
-class LoggingFunctor<A> implements Functor<A> {
+class LoggingFunctor<A> {
   constructor(public run: () => A, public msg: string) {}
   map<B>(fn: (a: A) => B): LoggingFunctor<B> {
     return new LoggingFunctor<B>(() => fn(this.run()), this.msg);


### PR DESCRIPTION
remove typescript binding bits which assume higher-kinded types support: those bits break with typescript 2.4. Fixes #144 the library now builds OK with typescript 2.4+.

It's a shame to lose this but that's the language we have. See my latest comment in #144.

@estaub suggested in #144 to keep the interfaces but just comment their contents, but I don't see the point. We can explain the interfaces in the documentation, no need to list them in the .d.ts files I guess.

I also noticed that it seems we don't anymore ship the generated files in git? That would mean two things:

1. the `CONTRIBUTING.md` is outdated because it suggests to run `npm run publ`
2. according to my understanding, it's now impossible for an application to depend on a git tag of monet, like this for instance `"monet": "https://github.com/cwmyers/monet.js/tarball/575dafec572b7e01bc9071ee969a7f9771207964"`. That's a letdown because monet is not released very often. If that's true and you accept this PR, I suggest to release a new alpha quickly after pulling this PR so people depending on monet can migrate to TS 2.4 -- previously they could have done it by referring to a git tag, but now they could be stuck