### PR TITLE
Added "do notation" for Maybe, Either, Validation and IO Monads using generators

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    browsers: ['PhantomJS'],
+    browsers: ['ChromeHeadless'],
     singleRun: true,
     concurrency: 6e6
   });

--- a/src/monet.js
+++ b/src/monet.js
@@ -65,6 +65,16 @@
         Free: 'Free'
     }
 
+    function doNotation(monad, co) {
+        function iterate (el) {
+            return el.done ? monad.unit(el.value) : el.value.bind(function (val) {
+                return iterate(it.next(val))
+            })
+        }
+        var it = co()
+        return iterate(it.next())
+    }
+
     function setType(target, typeName) {
         target[TYPE_KEY] = 'Monet/' + typeName
     }
@@ -632,6 +642,8 @@
     Maybe.toList = function (maybe) {
         return maybe.toList()
     }
+
+    Maybe.do = doNotation.bind(null, Maybe)
 
     Maybe.fn = Maybe.prototype = {
         init: function (isValue, val) {

--- a/src/monet.js
+++ b/src/monet.js
@@ -769,6 +769,8 @@
         return Success(v)
     }
 
+    Validation.do = doNotation.bind(null, Validation)
+
     Validation.fn = Validation.prototype = {
         init: function (val, success) {
             this.val = val

--- a/src/monet.js
+++ b/src/monet.js
@@ -930,6 +930,8 @@
         })
     }
 
+    IO.do = doNotation.bind(null, IO)
+
     IO.fn = IO.prototype = {
         init: function (effectFn) {
             if (!isFunction(effectFn)) {

--- a/src/monet.js
+++ b/src/monet.js
@@ -985,6 +985,8 @@
         return new Either.fn.init(val, false)
     }
 
+    Either.do = doNotation.bind(null, Either)
+
     Either.fn = Either.prototype = {
         init: function (val, isRightValue) {
             this.isRightValue = isRightValue

--- a/test/either-spec.js
+++ b/test/either-spec.js
@@ -293,4 +293,51 @@ describe('An Either', function () {
 
     })
 
+    describe('do notation', function() {
+        it('will yield the Right value inside a generator', function () {
+            Either.do(function*() {
+                var a = yield Either.Right(5)
+                expect(a).toBe(5)
+                return a
+            })
+        })
+
+        it('will return the value wrapped in Right', function() {
+            var result = Either.do(function* () {
+                var a = yield Either.Right(5)
+                var b = yield Either.Right(1)
+                return a + b
+            })
+
+            expect(result).toBeRightWith(6)
+        })
+
+        it('will return Left when Left is yielded inside the generator', function() {
+            var result = Either.do(function* () {
+                var a = yield Either.Right(5)
+                var b = yield Either.Left(10)
+                return a + b
+            })
+
+            expect(result).toBeLeftWith(10)
+        })
+
+        it('will short-circuit the generator when Left is yielded', function() {
+            var spyBeforeLeft = jasmine.createSpy()
+            var spyAfterLeft = jasmine.createSpy()
+
+            var result = Either.do(function* () {
+                spyBeforeLeft()
+                var a = yield Either.Left(5)
+                spyAfterLeft()
+                var b = yield Either.Right(3)
+                return a + b
+            })
+
+            expect(spyBeforeLeft).toHaveBeenCalled()
+            expect(spyAfterLeft).not.toHaveBeenCalled()
+            expect(result).toBeLeftWith(5)
+        })
+    })
+
 })

--- a/test/io-spec.js
+++ b/test/io-spec.js
@@ -51,4 +51,28 @@ describe('An IO monad', function () {
         expect(effect.ap).toBe(effect['fantasy-land/ap'])
       })
     })
+
+    describe('do notation', function() {
+        it('will yield the Success value inside a generator', function () {
+            var effect = IO.do(function* () {
+                var a = yield IO.of(5)
+                expect(a).toBe(5)
+                return a
+            })
+
+            effect.run()
+        })
+
+        it('will return the value wrapped IO', function() {
+            var effect = IO.do(function* () {
+                var a = yield IO.of(5)
+                var b = yield IO.of(1)
+                return a + b
+            })
+
+            effect.map(function (val) {
+                expect(val).toBe(6)
+            }).run()
+        })
+    })
 })

--- a/test/maybe-spec.js
+++ b/test/maybe-spec.js
@@ -454,6 +454,7 @@ describe('A Maybe', function () {
             Maybe.do(function*() {
                 var a = yield Maybe.Just(5)
                 expect(a).toBe(5)
+                return a
             })
         })
 
@@ -464,8 +465,7 @@ describe('A Maybe', function () {
                 return a + b
             })
 
-            expect(result.isJust()).toBe(true)
-            expect(result.toBeSomeMaybeWith(6))
+            expect(result).toBeSomeMaybeWith(6)
         })
 
         it('will return Nothing when Nothing is yielded inside the generator', function() {
@@ -475,7 +475,7 @@ describe('A Maybe', function () {
                 return a + b
             })
 
-            expect(result.toBeNoneMaybe)
+            expect(result).toBeNoneMaybe()
         })
 
         it('will short-circuit the generator when Nothing is yielded', function() {

--- a/test/maybe-spec.js
+++ b/test/maybe-spec.js
@@ -449,5 +449,50 @@ describe('A Maybe', function () {
         })
     })
 
+    describe('do notation', function() {
+        it('will yield the Just value inside a generator', function () {
+            Maybe.do(function*() {
+                var a = yield Maybe.Just(5)
+                expect(a).toBe(5)
+            })
+        })
 
+        it('will return the value wrapped in Just', function() {
+            var result = Maybe.do(function* () {
+                var a = yield Maybe.Just(5)
+                var b = yield Maybe.Just(1)
+                return a + b
+            })
+
+            expect(result.isJust()).toBe(true)
+            expect(result.toBeSomeMaybeWith(6))
+        })
+
+        it('will return Nothing when Nothing is yielded inside the generator', function() {
+            var result = Maybe.do(function* () {
+                var a = yield Maybe.Just(5)
+                var b = yield Maybe.Nothing()
+                return a + b
+            })
+
+            expect(result.toBeNoneMaybe)
+        })
+
+        it('will short-circuit the generator when Nothing is yielded', function() {
+            var spyBeforeNothing = jasmine.createSpy()
+            var spyAfterNothing = jasmine.createSpy()
+
+            var result = Maybe.do(function* () {
+                spyBeforeNothing()
+                var a = yield Maybe.Nothing()
+                spyAfterNothing()
+                var b = yield Maybe.Just(3)
+                return a + b
+            })
+
+            expect(spyBeforeNothing).toHaveBeenCalled()
+            expect(spyAfterNothing).not.toHaveBeenCalled()
+            expect(result).toBeNoneMaybe()
+        })
+    })
 })

--- a/test/validation-spec.js
+++ b/test/validation-spec.js
@@ -281,4 +281,51 @@ describe('A Validation', function () {
 
     })
 
+    describe('do notation', function() {
+        it('will yield the Success value inside a generator', function () {
+            Validation.do(function*() {
+                var a = yield Validation.Success(5)
+                expect(a).toBe(5)
+                return a
+            })
+        })
+
+        it('will return the value wrapped in Success', function() {
+            var result = Validation.do(function* () {
+                var a = yield Validation.Success(5)
+                var b = yield Validation.Success(1)
+                return a + b
+            })
+
+            expect(result).toBeSuccessWith(6)
+        })
+
+        it('will return Fail when Left is yielded inside the generator', function() {
+            var result = Validation.do(function* () {
+                var a = yield Validation.Success(5)
+                var b = yield Validation.Fail(10)
+                return a + b
+            })
+
+            expect(result).toBeFailureWith(10)
+        })
+
+        it('will short-circuit the generator when Fail is yielded', function() {
+            var spyBeforeFail = jasmine.createSpy()
+            var spyAfterFail = jasmine.createSpy()
+
+            var result = Validation.do(function* () {
+                spyBeforeFail()
+                var a = yield Validation.Fail(5)
+                spyAfterFail()
+                var b = yield Validation.Success(3)
+                return a + b
+            })
+
+            expect(spyBeforeFail).toHaveBeenCalled()
+            expect(spyAfterFail).not.toHaveBeenCalled()
+            expect(result).toBeFailureWith(5)
+        })
+    })
+
 })


### PR DESCRIPTION
Added a generic `doNotation` function, which is bound to monads `Maybe`, `Either`, `Validation` and `IO` as a static `do` method. This will allow one to have a similar experience as Haskell's `do` using ES6 generators.

Example:
```
Maybe.do(function*() {
  var a = yield Maybe.Just(5)
  var b = yield Maybe.Just(1)
  return a+b
}) // => Just(6)
```

The new library code itself doesn't require ES6, but the unit tests do, thus it was required to drop PhantomJS in favour of headless Chrome for unit tests (PhantomJS is abandoned anyway).

This PR doesn't include TypeScripy bindings yet, as it would require the `IterableIterator` type which would make the `es6` target mandatory.