### PR TITLE
Add NonNullable return type requirement for Maybe.map

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "karma-jasmine": "1.1.0",
     "karma-phantomjs-launcher": "1.0.4",
     "karma-safari-launcher": "1.0.0",
-    "typescript": "2.6.1",
+    "typescript": "2.8.1",
     "uglify-js": "3.1.6"
   },
   "scripts": {

--- a/src/monet.d.ts
+++ b/src/monet.d.ts
@@ -118,7 +118,7 @@ export interface Maybe<T>
   bind<V>(fn: (val: T) => Maybe<V>): Maybe<V>;
   flatMap<V>(fn: (val: T) => Maybe<V>): Maybe<V>;
   chain<V>(fn: (val: T) => Maybe<V>): Maybe<V>;
-  map<V>(fn: (val: T) => V): Maybe<V>;
+  map<V extends NonNullable<{}>>(fn: (val: T) => V): Maybe<V>;
   join<V>(): Maybe<V>; // if T is Identity<V>
   takeLeft(m: Maybe<T>): Maybe<T>;
   takeRight(m: Maybe<T>): Maybe<T>;

--- a/test/typings/maybe-spec.ts
+++ b/test/typings/maybe-spec.ts
@@ -68,16 +68,34 @@ log3b(getMessage({type: 'x', payload: null}).chain(getType));
 
 const name: string = None<string>().orSome('NAME');
 const surname: string = Nothing<string>().orJust('SURNAME');
-const message: string = Maybe.Just(0).filter(Boolean).map(String).orElse(unpacked).orJust('Hi!');
+const message: string = Maybe.Just(0).filter(Boolean).map<string>(String).orElse(unpacked).orJust('Hi!');
 const messageCopy: string = Maybe.Nothing().ap(unpacked.map(m => () => m)).orSome('Hi!');
 Maybe.Just("hello").orNoneIf(false).forEach((str:string) => console.log(str));
 None<string>().orNothingIf(true).orElseRun(() => console.log("oops"));
 
 const plus18 = (val: number) => val + 18;
 
+interface Foo {
+    bar: string
+}
+
 console.assert(Maybe.some(12).map(plus18).some() == 30);
+console.assert(Maybe.some(12).map<number>(plus18).some() == 30);
+console.assert(Maybe.some("hi").map<string>(String).some() == "hi");
+console.assert(Maybe.some([1,2]).map<number[]>(l => l).some() == [1,2]);
+console.assert(Maybe.some({bar: "foobar"}).map<{[k: string]: string}>(l => l).some() == {bar: "foobar"});
+console.assert(Maybe.some({bar: "foobar"}).map<Foo>(l => l).some() == {bar: "foobar"});
 console.assert(Maybe.none<number>().map(plus18).isNone());
+console.assert(Maybe.none<number>().map<number>(plus18).isNone());
 console.assert(Some(11).map(plus18).isNone());
 console.assert(Maybe.of('a').flatMap(a => Some(a + 'b')).orNull() === null);
 console.assert(Maybe.of('a').filter(Boolean).orJust('b') === null);
 console.log(name, surname, message, messageCopy);
+
+// Remove comment to test NonNullable return type by forcing the type check to fail
+/*
+console.assert(Maybe.some(12).map(n => {}).isSome());
+console.assert(Maybe.some(12).map(n => null).isSome());
+console.assert(Maybe.some(12).map(n => undefined).isSome());
+console.assert(Maybe.some(12).map(n => { n++; }).isSome());
+*/

--- a/test/typings/nel-spec.ts
+++ b/test/typings/nel-spec.ts
@@ -5,7 +5,7 @@ const nonempty: NonEmptyList<number> = NEL(0, List(12));
 const nelBool: NEL<boolean> = nel.flatMap((str: string) => NEL.of(!str, List(Boolean(str))));
 const nil = nelBool.filter(a => a).filter(a => !a);
 const nel2 = NEL.fromList(nil).cata(() => NEL.unit(true), a => a);
-const nel3 = NEL.fromList(Nil).cata(() => NEL.pure(true), a => a);
+const nel3 = NEL.fromList(Nil).cata(() => NEL.pure(undefined), a => a);
 const taken: NonEmptyList<number> = nel2.takeLeft(nel3).takeRight(nonempty);
 const tail: List<number> = taken.tail();
 const xx: NEL<number> = taken.tails().map(e => e.head()).mapTails(t => t.extract()).cojoin().bind(t => t).reverse();


### PR DESCRIPTION
This updates the typings file to be consistent with the javascript which
prevents `null` values from being initialized within a `Maybe`.

The `NonNullable` type requires TypeScript 2.8+.

Additionally, the TS update brings better type coverage which caused one
`NEL` test to fail and has been updated to reflect the correct type.