### PR TITLE
Add attempt to Either

### DIFF
--- a/src/monet.d.ts
+++ b/src/monet.d.ts
@@ -249,6 +249,7 @@ interface IEitherStatic extends IMonadStatic {
   unit: IRightStatic;
   of: IRightStatic;    // alias for unit
   pure: IRightStatic;  // alias for unit
+  attempt<E, V>(fn: () => V): Either<Error|E, V>;
   isOfType(target: any): boolean;
   isInstance(target: any): target is Either<any, any>;
 }

--- a/src/monet.js
+++ b/src/monet.js
@@ -1033,6 +1033,14 @@
         return new Either.fn.init(val, false)
     }
 
+    Either.attempt = function(fn) {
+        try {
+            return Right(fn())
+        } catch (e) {
+            return Left(e)
+        }
+    }
+
     Either.fn = Either.prototype = {
         init: function (val, isRightValue) {
             this.isRightValue = isRightValue

--- a/test/either-spec.js
+++ b/test/either-spec.js
@@ -307,4 +307,24 @@ describe('An Either', function () {
 
     })
 
+    var e = new Error("some error");
+    var eObj = {foo: "error"};
+    var noThrow = Either.attempt(function() { return "yay"; });
+    var throwError = Either.attempt(function() { throw e; });
+    var throwErrorObj = Either.attempt(function() { throw eObj; });
+    describe('attempt will produce', function() {
+        it('a right for successful function call', function() {
+            expect(noThrow).toBeRightWith("yay")
+            expect(noThrow.isLeft()).toBe(false)
+        })
+        it('a left for a function that throws an Error', function() {
+            expect(throwError).toBeLeftWith(e)
+            expect(throwError.isRight()).toBe(false)
+        })
+        it('a left for a function that throws an object', function() {
+            expect(throwErrorObj).toBeLeftWith(eObj)
+            expect(throwErrorObj.isRight()).toBe(false)
+        })
+    })
+
 })

--- a/test/typings/either-spec.ts
+++ b/test/typings/either-spec.ts
@@ -75,3 +75,24 @@ console.assert(twelve.right() === 12);
 console.assert(oops.left() === "oops");
 
 console.log(nameError, messageCopy);
+
+function noThrow<E>(): Either<Error | E, string> {
+    return Either.attempt(() => "yay");
+}
+
+const e = new Error("Some error");
+const eObj = {err: "Some error"};
+function catchError<E>(): Either<Error | E, string> {
+    return Either.attempt(() => {throw e; });
+}
+
+function catchErrorObj<E>(): Either<Error | E, string> {
+  return Either.attempt(() => {throw eObj; });
+}
+
+console.assert(noThrow().right() === "yay");
+console.assert(noThrow().left() === "yay");
+console.assert(catchError().left() === e);
+console.assert(catchError().cata((e: Error | any) => e instanceof Error, () => false));
+console.assert(catchErrorObj().left() === eObj);
+console.assert(catchErrorObj().cata((e: Error | any) => !(e instanceof Error), () => false));


### PR DESCRIPTION
This adds a convenience function to `Either` that will produce an `Either<Error|E, V>` where the left is the result from a `try/catch` and the right is the result of a `fn: () => V`.

Since pretty much any type of thing can be `thrown` in JS the type cant be locked down to just `Either<Error, V>`. However, adding the union of `Error|E` will provide at least a little bit of type help to TS users.

Prior art comes from `fromTryCatchNonFatal` (recently renamed to `attempt` in v7.3) of ScalaZ `disjunctions` which are simply right biased `Either`s just as in monet.js.

I am happy to change the function name to something like `fromTryCatch` if that makes it clearer as to what it does. 