### PR TITLE
Require a return value for all transformative functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-firefox-launcher": "1.1.0",
     "karma-jasmine": "1.1.2",
     "karma-mocha-reporter": "2.2.5",
-    "typescript": "3.0.3",
+    "typescript": "3.1.3",
     "uglify-js": "3.4.9"
   },
   "scripts": {

--- a/test/typings/either-spec.ts
+++ b/test/typings/either-spec.ts
@@ -74,4 +74,9 @@ const oops: Either<string, number> = Either.left<string,number>("oops");
 console.assert(twelve.right() === 12);
 console.assert(oops.left() === "oops");
 
+// uncomment to fail typecheck for non return value
+// twelve.map(() => { "no return"; });
+// twelve.leftMap(() => { "no return"; });
+// twelve.cata(() => { "no return" }, () => { "no return"; });
+
 console.log(nameError, messageCopy);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,18 +3,12 @@
     "listFiles": true,
     "lib": ["dom", "es5", "es2015.collection", "es2015.iterable"],
     "noEmit": true,
-    "noImplicitAny": true,
+    "noErrorTruncation": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "strict": true
   },
-  "files": [
-    "test/typings/identity-spec.ts",
-    "test/typings/maybe-spec.ts",
-    "test/typings/either-spec.ts",
-    "test/typings/validation-spec.ts",
-    "test/typings/list-spec.ts",
-    "test/typings/nel-spec.ts",
-    "test/typings/io-spec.ts",
-    "test/typings/reader-spec.ts",
-    "test/typings/free-spec.ts"
+  "include": [
+    "test/typings/*"
   ]
 }


### PR DESCRIPTION
This enforces that calls to `map`, `leftMap`, `cata`, etc. provide a return value where it is expected.

Requires TypeScript 2.8+.