### PR TITLE
Fix example in IO docs

### DIFF
--- a/docs/IO.md
+++ b/docs/IO.md
@@ -95,7 +95,7 @@ const read = id => IO(() => $(id).text())
 const write = id => value => IO(() => $(id).text(value))
 ```
 
-You can call `write(id)` until you are blue in the face but all it will do is return an `IO` with a function inside.
+You can call `write(id)('foo')` until you are blue in the face but all it will do is return an `IO` with a function inside.
 
 We can now call `map` and `flatMap` to chain this two effects together. Say we wanted to read from a `div`, convert all the text to uppercase and then write back to that `div`.
 


### PR DESCRIPTION
`write(id)` returns just a regular function. I was choosing between `read(id)` and `write(id)('foo')`, decided to go with second, as for me it emphasise that invocation changes nothing. 