### PR TITLE
Update node.js version in travis to oldest maintained.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
 
 branches:
   only:


### PR DESCRIPTION
Looks like travis fails because of quite old node.js & modern eslint.js which uses modern syntax. Updated node to 10(oldest maintained) version @ulfryk 